### PR TITLE
Fix html syntax errors

### DIFF
--- a/download.html
+++ b/download.html
@@ -50,9 +50,8 @@
 <h3>1. Download the latest live image</h3>
 <p>Download the latest stable 64-bit version of Rescuezilla: <strong><a href="https://github.com/rescuezilla/rescuezilla/releases/download/2.4.2/rescuezilla-2.4.2-64bit.jammy.iso">rescuezilla-2.4.2-64bit.jammy.iso</a></strong> (recommended).</p>
 <p>Checkout the Rescuezilla GitHub release page for information about <a href="https://github.com/rescuezilla/rescuezilla/releases/latest">what's new, backwards compatibility, and any bug advisories</a>.</p>
-</p>
 <h3>2. Write the image to a USB</h3>
-<p>You'll need to write the image to a USB drive using a program such as <a target="_blank" href="https://www.balena.io/etcher/">balenaEtcher</a> which works on Windows, Mac and Linux. <strong>This step will completely erase any data on your USB stick.</strong></strong></p>
+<p>You'll need to write the image to a USB drive using a program such as <a target="_blank" href="https://www.balena.io/etcher/">balenaEtcher</a> which works on Windows, Mac and Linux. <strong>This step will completely erase any data on your USB stick.</strong></p>
 <h3>3. Reboot your computer</h3>
 <p>Rescuezilla does not run from inside Windows or any other operating system <strong>because it is one</strong><strong>!</strong> You must restart your computer with the USB inserted in order to use Rescuezilla. To boot from the USB, you may need to repeatedly press a key such as <strong>F8</strong> or <strong>F12 </strong>while your computer is starting up.</p>
 <h3>4. Enjoy!</h3>

--- a/help.html
+++ b/help.html
@@ -59,7 +59,7 @@
   <h3>Q: I am having trouble connecting to a SMB/CIFS (Samba) network shared folder</h3>
   <p>A: First make sure the server field has the correct UNC path (eg "\\fileserver\Users\fred\MySharedFolder"), username and password.</p>
   <p>Some network shares may not support the default SMB2+ protocol. For such devices you can try <strong>'1.0' in the version field. This is often the case with NAS devices and older versions of Windows.</strong></p>
-  <p>Please make sure you're using the latest version of Rescuezilla, because there has been improvements around shared folders.</strong></p>
+  <p>Please make sure you're using the latest version of Rescuezilla, because there has been improvements around shared folders.</p>
 </div>
 <div class="faq rounded">
 <h3>Q: I restored my Linux backup using Rescuezilla. It boots past the GRUB bootloader fully, but the Linux boot gets stuck at "Rescue Mode" login prompt. How do I fix this?</h3>

--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@
 <h2 style="clear: left;">Future development</h2>
 <p>Rescuezilla's ambitious roadmap is being developed on <a target="_blank" href="https://github.com/rescuezilla/rescuezilla/wiki/Rescuezilla-Project-Roadmap">GitHub</a>. Future plans include a graphical tool to extract individual files from backup images, a data-salvage tool to rescue data from dying hard drives and much more! <strong>Consider contributing <a target="_blank" href="https://www.patreon.com/join/rescuezilla">$1/month on the crowdfunding website Patreon</a> so that <strong>Rescuezilla</strong> can continue to be developed.</strong></p>
 <h2 style="clear: left;">Discussion forum</h2>
-<p>Feel free to chat with other users on the <a target="_blank" href="https://sourceforge.net/p/rescuezilla/discussion/">official Rescuezilla Sourceforge forum</a>.</strong></p>
+<p>Feel free to chat with other users on the <a target="_blank" href="https://sourceforge.net/p/rescuezilla/discussion/">official Rescuezilla Sourceforge forum</a>.</p>
 <h2>See the <a href="./features">feature list</a> or <a href="./download">download the latest version</a>.</h2>
 <div><div class="orangebox rounded">
   <h2>Like Rescuezilla?</h2>


### PR DESCRIPTION
download.html:

- Remove redundant closed tag 'p' in line 53
- Remove redundant closed tag 'strong' in line 55

help.html:

- Remove redundant closed tag 'strong' in line 62

index.html:

- Remove redundant closed tag 'strong' in line 78

Discovered by running the following 'html2po' command step by step:

```bash
$ html2po --pot --input=xxx.html --output=xxx.pot --progress none
```